### PR TITLE
docs: fix simple typo, treshold -> threshold

### DIFF
--- a/Firmware/LPC-Link-II/usbd_LPC43xx_USB0.c
+++ b/Firmware/LPC-Link-II/usbd_LPC43xx_USB0.c
@@ -196,7 +196,7 @@ void USBD_Reset (void) {
   LPC_USB0->ENDPTFLUSH = 0xFFFFFFFF;
   while (LPC_USB0->ENDPTFLUSH);
 
-  LPC_USB0->USBCMD_D &= ~0x00FF0000;    /* immediate intrrupt treshold        */
+  LPC_USB0->USBCMD_D &= ~0x00FF0000;    /* immediate intrrupt threshold        */
 
   /* clear ednpoint queue heads                                               */
   ptr = (uint8_t *)EPQHx;


### PR DESCRIPTION
There is a small typo in Firmware/LPC-Link-II/usbd_LPC43xx_USB0.c.

Should read `threshold` rather than `treshold`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md